### PR TITLE
Shapely values for global sensitivity analysis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,4 @@ max-line-length = 100
 
 [flake8_nb]
 max-line-length = 100
+


### PR DESCRIPTION
We want to be able to compute the Shapley values for economic models.

- [ ] set up interface to [shapleyPermEx](https://cran.r-project.org/web/packages/sensitivity/sensitivity.pdf) 
- [ ] reproduce results for various test functions to ensure functionality, see [here](https://rdrr.io/cran/sensitivity/man/shapleyPermEx.html) for an example
- [ ] appyl to Harris EOQ model for documentation