### PR TITLE
fix PYTHONPATH

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,6 +42,8 @@ jobs:
       shell: bash -l {0}
       run: |
         export PATH="$PATH:/usr/share/miniconda/bin"
+        source .envrc
+
         cd docs/_static/codes
         python fig-illustrations.py
         python fig-harris-tradeoff.py


### PR DESCRIPTION
The submodules are added in the `.envrc` file and it needs to be processed before drawing on any resources there.